### PR TITLE
Fix #1: Warning when using extract

### DIFF
--- a/cf7_gated_content.php
+++ b/cf7_gated_content.php
@@ -100,6 +100,7 @@ class ContactFormGatedContent {
 	 * @access public
 	 */
 	public static function saveGatedContentForm( $contact_form ) {
+		global $post;
 		$contact_form_id = $contact_form->id();
 		$meta = array();
 
@@ -119,7 +120,7 @@ class ContactFormGatedContent {
 		}
 
 		// Don't save on revisions
-		if ( 'revision' === $post->post_type ) {
+		if ($post && 'revision' === $post->post_type ) {
 			return $contact_form_id;
 		}
 
@@ -127,8 +128,8 @@ class ContactFormGatedContent {
 		$meta['image_attachment_url'] = sanitize_text_field($_POST['image_attachment_url']);
 		$meta['download_button_text'] = sanitize_text_field($_POST['download_button_text']);
 		$meta['download_button_classes'] = sanitize_text_field($_POST['download_button_classes']);
-		$meta['always_require_form'] = !!$_POST['always_require_form'];
-		$meta['include_default_css'] = !!$_POST['include_default_css'];
+		$meta['always_require_form'] = !!(isset($_POST['always_require_form']) ? $_POST['always_require_form'] : false);
+		$meta['include_default_css'] = !!(isset($_POST['include_default_css']) ? $_POST['include_default_css'] : false);
 		$meta['download_content'] = wp_kses_post($_POST['download_content']);
 
 		foreach ( $meta as $key => $value ) {
@@ -206,7 +207,11 @@ class ContactFormGatedContent {
 	 * @access public
 	 */
 	public static function outputShortcode($output, $tag, $atts, $m) {
-		extract($atts, EXTR_SKIP);
+		if ($tag != 'contact-form-7') { return ''; }
+
+		$id = $atts ? $atts['id'] : null;
+
+		if (!$id) { return ''; }
 
 		$gated_content_url = get_post_meta($id, 'image_attachment_url', true);
 		$include_default_css = get_post_meta($id, 'include_default_css', true);
@@ -314,9 +319,9 @@ class ContactFormGatedContent {
 			include $path;
 			return ob_get_clean();
 		}
-    }
+		}
 
-    /**
+		/**
 	 * Get default values for gated content settings
 	 *
 	 * @return Array    the array of default values
@@ -334,9 +339,9 @@ class ContactFormGatedContent {
 			"attachment_meta" => null,
 			"include_default_css" => true
 		);
-    }
+		}
 
-    /**
+		/**
 	 * Helper to store meta values
 	 *
 	 * @since 1.0.0


### PR DESCRIPTION
This resolves #1.

**Repro Steps**
The issue reproduces if you put an empty short-code on a page while the gated content plugin is active. 

For example, active the plugin, the add the shortcode `[gallery]` to any page.

**Explanation**
`$atts` ends up not being set by WP, which means `extract()` fails because it is not an array. I've opted to replace the use of `extract()` entirely, as a couple other sources suggested it's not recommended by WP core. Since we're only using it to get one parameter, I'm simply setting `$id` by accessing it from `$atts` if `$atts` exists.

There are a couple other small fixes for other warnings and notices that shows up. The one I'm most suspicious of are the changes to the `'revision' === $post->post_type` guard. I have no idea what that guard is doing, but $post both wasn't defined and wasn't set, which was blowing up.